### PR TITLE
Upgrade to raze 1.10.0

### DIFF
--- a/org.zdoom.Raze.yaml
+++ b/org.zdoom.Raze.yaml
@@ -67,8 +67,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/ZDoom/Raze.git
-    tag: "1.9"
-    commit: 9af265b5ea1ab2872368ae58ad3b5490fab658f1
+    tag: "1.10.0"
+    commit: 9a068cf7c9c00f1a79c307bc2bf022faab6bf2b5
   - type: script
     commands:
       - raze +fluid_patchset /app/share/games/raze/soundfonts/raze.sf2 "$@"


### PR DESCRIPTION
[raze 1.10.0 has been released](https://github.com/ZDoom/Raze/releases/tag/1.10.0). It includes important fixes that are relevant to Linux users, especially for filesystem paths. This PR changes the version of raze to point to the 1.10.0 tag and commit hash.

I tested this locally on my machine with Duke Nukem 3D. [Here's the full output and screenshot.](https://gist.github.com/Imxset21/4afa3042984a3ee14a4168d84e2c807e)

Thanks for making this flatpak!